### PR TITLE
Fix Upptime CI blocked by master branch protection

### DIFF
--- a/.github/workflows/graphs.yml
+++ b/.github/workflows/graphs.yml
@@ -31,6 +31,8 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT || github.token }}
+      - name: Pull latest changes
+        run: git pull origin master
       - name: Generate graphs
         uses: upptime/uptime-monitor@v1.42.7
         with:

--- a/.github/workflows/response-time.yml
+++ b/.github/workflows/response-time.yml
@@ -31,6 +31,8 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT || github.token }}
+      - name: Pull latest changes
+        run: git pull origin master
       - name: Update response time
         uses: upptime/uptime-monitor@v1.42.7
         with:

--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -32,6 +32,8 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT || github.token }}
+      - name: Pull latest changes
+        run: git pull origin master
       - name: Update template
         uses: upptime/uptime-monitor@v1.42.7
         with:

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -32,6 +32,8 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT || github.token }}
+      - name: Pull latest changes
+        run: git pull origin master
       - name: Generate site
         uses: upptime/uptime-monitor@v1.42.7
         with:

--- a/.github/workflows/summary.yml
+++ b/.github/workflows/summary.yml
@@ -31,6 +31,8 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT || github.token }}
+      - name: Pull latest changes
+        run: git pull origin master
       - name: Update summary in README
         uses: upptime/uptime-monitor@v1.42.7
         with:

--- a/.github/workflows/update-template.yml
+++ b/.github/workflows/update-template.yml
@@ -31,8 +31,10 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT || github.token }}
+      - name: Pull latest changes
+        run: git pull origin master
       - name: Update template
-        uses: upptime/uptime-monitor@master
+        uses: upptime/uptime-monitor@v1.42.7
         with:
           command: "update-template"
         env:

--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -31,6 +31,8 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT || github.token }}
+      - name: Pull latest changes
+        run: git pull origin master
       - name: Check endpoint status
         uses: upptime/uptime-monitor@v1.42.7
         with:


### PR DESCRIPTION
## Summary
- Add `git pull origin master` before Upptime monitor steps to avoid push races when multiple workflows commit close together.
- Pin `update-template.yml` to `upptime/uptime-monitor@v1.42.7` instead of `@master`.

## Root cause (requires admin follow-up)
All Upptime workflows fail with `GH013: Changes must be made through a pull request` because the **Require Pull Requests** ruleset on `master` (ruleset `15295551`, added 2026-04-20) blocks direct pushes from `upptime-bot` / `GH_PAT`.

Upptime must commit directly to `master`; it cannot use PRs. After merging this PR, a repo admin must add **`upptime-bot`** as a bypass actor on that ruleset:

https://github.com/wrktech/status-page/rules/15295551 → Edit → **Bypass list** → add `upptime-bot`

## Merge history review
- **2026-04-20**: Branch protection rulesets added without an Upptime bypass → CI push failures start.
- **2026-04-27 (#1346)**: Back-end Systems removed from `.upptimerc.yml` (deprecation), but README/history still show it because CI could not regenerate.
- **2025-10-20 (#1330, #1333, #907)**: Jobcenter monitor added and labels updated; Renovate configured in same window — noisy but not breaking.
- **2026-06-19 (#1347, #1349)**: Renovate bumped `uptime-monitor` and `actions/checkout`; workflows updated but still blocked by ruleset.

## Test plan
- [ ] Repo admin adds `upptime-bot` to ruleset bypass list
- [ ] Manually run **Uptime CI** and **Summary CI** from Actions
- [ ] Confirm commits land on `master` and README/history refresh

Made with [Cursor](https://cursor.com)